### PR TITLE
refactor(dashboard): remove unused Link import from page.tsx

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,6 @@
 "use client"
 
 import Image from "next/image"
-// (remove this line)
-import Link from "next/link"
 import { sampleprofile } from "../../../public"
 import Sidebar from "../../components/Sidebar"
 


### PR DESCRIPTION
The Link import was not being used in the dashboard page, so it has been removed to clean up the code and improve maintainability.