### PR TITLE
Itinerary generator

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import { sampleprofile } from "../../../public"
 import Sidebar from "../../components/Sidebar"
+import Link from "next/link"
 
 const Dashboard = () => {
   return (
@@ -21,11 +22,13 @@ const Dashboard = () => {
             </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-            <div className="bg-white rounded-2xl shadow p-8 flex flex-col items-center justify-center text-center cursor-pointer hover:shadow-lg transition">
-              <div className="text-3xl mb-2">+</div>
-              <div className="font-semibold text-lg">Create New Itinerary</div>
-              <div className="text-gray-500 text-sm mt-1">Create a personalized travel plan</div>
-            </div>
+            <Link href="/itinerary-generator" className="block">
+              <div className="bg-white rounded-2xl shadow p-8 flex flex-col items-center justify-center text-center cursor-pointer hover:shadow-lg transition">
+                <div className="text-3xl mb-2">+</div>
+                <div className="font-semibold text-lg">Create New Itinerary</div>
+                <div className="text-gray-500 text-sm mt-1">Create a personalized travel plan</div>
+              </div>
+            </Link>
             <div className="bg-white rounded-2xl shadow p-8 flex flex-col items-center justify-center text-center cursor-pointer hover:shadow-lg transition">
               <div className="mb-2">
                 <svg width="28" height="28" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 21v-2a4 4 0 00-4-4H7a4 4 0 00-4 4v2" /><circle cx="9" cy="7" r="4" /></svg>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,9 +3,10 @@
 import Image from "next/image"
 import { sampleprofile } from "../../../public"
 import Sidebar from "../../components/Sidebar"
-import Link from "next/link"
+import { useRouter } from "next/navigation"
 
 const Dashboard = () => {
+  const router = useRouter()
   return (
     <div className="min-h-screen bg-[#f7f9fb]">
       {/* Sidebar */}
@@ -22,13 +23,11 @@ const Dashboard = () => {
             </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-            <Link href="/itinerary-generator" className="block">
-              <div className="bg-white rounded-2xl shadow p-8 flex flex-col items-center justify-center text-center cursor-pointer hover:shadow-lg transition">
-                <div className="text-3xl mb-2">+</div>
-                <div className="font-semibold text-lg">Create New Itinerary</div>
-                <div className="text-gray-500 text-sm mt-1">Create a personalized travel plan</div>
-              </div>
-            </Link>
+            <div className="bg-white rounded-2xl shadow p-8 flex flex-col items-center justify-center text-center cursor-pointer hover:shadow-lg transition" onClick={() => router.push("/itinerary-generator")}>
+              <div className="text-3xl mb-2">+</div>
+              <div className="font-semibold text-lg">Create New Itinerary</div>
+              <div className="text-gray-500 text-sm mt-1">Create a personalized travel plan</div>
+            </div>
             <div className="bg-white rounded-2xl shadow p-8 flex flex-col items-center justify-center text-center cursor-pointer hover:shadow-lg transition">
               <div className="mb-2">
                 <svg width="28" height="28" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 21v-2a4 4 0 00-4-4H7a4 4 0 00-4 4v2" /><circle cx="9" cy="7" r="4" /></svg>

--- a/src/app/itinerary-generator/page.tsx
+++ b/src/app/itinerary-generator/page.tsx
@@ -109,7 +109,7 @@ export default function ItineraryGenerator() {
             {/* Number of Pax */}
             <div>
               <Label className="block font-bold mb-2 text-gray-700">Number of Pax.</Label>
-              <div className="grid grid-cols-4 gap-3">
+              <div className="grid grid-cols-4 gap-3 lg:mr-48">
                 {paxOptions.map(opt => (
                   <Button
                     type="button"
@@ -129,7 +129,7 @@ export default function ItineraryGenerator() {
             {/* Duration */}
             <div>
               <Label className="block font-bold mb-2 text-gray-700">Duration</Label>
-              <div className="grid grid-cols-4 gap-3">
+              <div className="grid grid-cols-4 gap-3 lg:mr-48">
                 {durationOptions.map(opt => (
                   <Button
                     type="button"
@@ -149,7 +149,7 @@ export default function ItineraryGenerator() {
             {/* Travel Dates */}
             <div>
               <Label className="block font-bold mb-2 text-gray-700">Travel Dates</Label>
-              <div className="flex gap-3">
+              <div className="flex gap-3 lg:mr-48">
                 <Input
                   type="date"
                   className={cn(

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,7 +35,7 @@ const Sidebar = () => {
       </button>
 
       {/* Sidebar - hidden on mobile unless toggled */}
-      <aside className={`w-64 bg-white border-r border-gray-200 flex flex-col justify-between py-8 px-6 fixed inset-y-0 left-0 transform ${isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 transition-transform duration-300 ease-in-out z-40`}>
+      <aside className={`w-64 ${pathname === "/itinerary-generator" ? "bg-gray-100" : "bg-white"} border-r border-gray-200 flex flex-col justify-between py-8 px-6 fixed inset-y-0 left-0 transform ${isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 transition-transform duration-300 ease-in-out z-40`}>
         <div>
           <div className="text-2xl font-bold mb-12">
             Tarana.<span className="text-blue-500">ai</span>


### PR DESCRIPTION
style: adjust grid and flex layouts for responsiveness

Add `lg:mr-48` to grid and flex containers in the itinerary generator to improve responsiveness on larger screens

style(Sidebar): update background color based on route

The background color of the Sidebar component now changes to gray when the route is "/itinerary-generator" to improve visual distinction and user experience for specific pages.