### PR TITLE
feat: add remote image pattern for openweathermap.org

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,15 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   transpilePackages: ['lucide-react'], // Add lucide-react for proper module handling
   /* other config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'openweathermap.org',
+        pathname: '/img/wn/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Add a remote image pattern to the Next.js configuration to allow loading images from openweathermap.org. This change ensures that weather icons from the OpenWeatherMap API can be displayed correctly in the application.