### PR TITLE
fix(Reviews): remove redundant size prop from pagination buttons

### DIFF
--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -141,7 +141,7 @@ const Reviews = ({
           <div className="flex justify-center items-center gap-2 mt-6">
             <Button
               variant="outline"
-              size="icon"
+         
               onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
               disabled={currentPage === 1}
             >
@@ -156,7 +156,6 @@ const Reviews = ({
             
             <Button
               variant="outline"
-              size="icon"
               onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
               disabled={currentPage === totalPages}
             >


### PR DESCRIPTION
The size="icon" prop was unnecessarily applied to pagination buttons in the Reviews component. Since these buttons contain text labels ("Previous" and "Next"), the icon size was inappropriate and caused visual inconsistencies. The removal maintains consistent button sizing while improving usability.