### PR TITLE
chore: remove eslintignore file as it's no longer needed

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-# Ignore specific files with ESLint issues
-src/app/saved-trips/[id]/page.tsx
-src/app/itinerary-generator/page.tsx


### PR DESCRIPTION
The ignored files have been either fixed or removed, making the eslintignore file unnecessary. This cleanup helps maintain a cleaner project configuration.