### PR TITLE
fix: update signup links in Footer and HeroSection components

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
         <p className="text-lg mb-8">Tap below to start your smart travel experience.</p>
 
         <Link
-          href="#"
+          href="/auth/signup"
           className="inline-flex items-center justify-center bg-white text-blue-500 px-8 py-3 rounded-2xl text-lg font-medium hover:bg-gray-100 transition-colors"
         >
           Plan My Baguio Trip

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -28,7 +28,7 @@ const HeroSection = () => {
                         {/* CTA Button */}
                         <div className="absolute bottom-0">
                             <Link
-                                href="#"
+                                href="/auth/signup"
                                 className="bg-gradient-to-b from-blue-700 to-blue-500 text-white px-8 py-3 rounded-2xl text-lg font-medium hover:bg-blue-700 transition-colors flex items-center"
                             >
                                 Plan My Baguio Trip


### PR DESCRIPTION
Update placeholder "#" links to point to "/auth/signup" to properly direct users to the signup page when clicking "Plan My Baguio Trip" buttons