### PR TITLE
fix(auth): ensure token.id is set for google users

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -195,11 +195,24 @@ export const authOptions: NextAuthOptions = {
       return true;
     },
     async jwt({ token, user, account }) {
+      // Patch: Ensure token.id is set for Google users
       if (account && user) {
-        token.id = user.id
-        token.picture = user.image
+        if (account.provider === "google") {
+          // Fetch user from Supabase to get the id
+          const { data: dbUser } = await supabaseAdmin
+            .from('users')
+            .select('id')
+            .eq('email', user.email?.toLowerCase())
+            .single();
+          if (dbUser && dbUser.id) {
+            token.id = dbUser.id;
+          }
+        } else {
+          token.id = user.id;
+        }
+        token.picture = user.image;
       }
-      return token
+      return token;
     },
     async session({ session, token }) {
       if (session.user) {


### PR DESCRIPTION
Fetch user from Supabase when provider is Google to correctly set token.id. This fixes an issue where Google-authenticated users weren't getting their user ID properly set in the JWT token.