### PR TITLE
fix(api): improve reindex endpoint security and error handling

### DIFF
--- a/src/app/api/reindex/route.ts
+++ b/src/app/api/reindex/route.ts
@@ -1,37 +1,63 @@
 import { NextRequest, NextResponse } from "next/server";
 import { upsertActivityEmbedding } from "@/lib/vectorSearch";
 import { sampleItinerary } from "@/app/itinerary-generator/data/itineraryData";
+import { timingSafeEqual } from "crypto";
 
 // Simple auth via header X-ADMIN-TOKEN that must match env.REINDEX_SECRET
 const ADMIN_TOKEN = process.env.REINDEX_SECRET || "";
 
 export async function POST(req: NextRequest) {
   const providedToken = req.headers.get("x-admin-token") || "";
-  if (!ADMIN_TOKEN || providedToken !== ADMIN_TOKEN) {
+
+  // Ensure the secret is configured on the server and is not an empty string.
+  if (!ADMIN_TOKEN) {
+    console.error("REINDEX_SECRET is not set. Aborting.");
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Use a constant-time comparison to prevent timing attacks.
+  // Note: This requires the Node.js runtime, not the Edge runtime.
+  const providedTokenBuffer = Buffer.from(providedToken, "utf8");
+  const adminTokenBuffer = Buffer.from(ADMIN_TOKEN, "utf8");
+
+  if (
+    providedTokenBuffer.length !== adminTokenBuffer.length ||
+    !timingSafeEqual(providedTokenBuffer, adminTokenBuffer)
+  ) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const activities = sampleItinerary.items.flatMap((s) => s.activities);
-  let success = 0;
-  for (const act of activities) {
-    try {
-      const imageUrl = typeof act.image === "string" ? act.image : (act.image as any)?.src || "";
-      await upsertActivityEmbedding({
-        activity_id: act.title,
-        textForEmbedding: `${act.title}. ${act.desc}`,
-        metadata: {
-          title: act.title,
-          desc: act.desc,
-          tags: act.tags,
-          time: act.time,
-          image: imageUrl,
-        },
-      });
-      success += 1;
-    } catch (err) {
-      console.error("Failed to embed", act.title, err);
-    }
-  }
 
-  return NextResponse.json({ indexed: success, total: activities.length });
-} 
+  const upsertPromises = activities.map((act) => {
+    // Using `(act.image as any)` suggests the type could be more specific.
+    const imageUrl =
+      typeof act.image === "string" ? act.image : (act.image as any)?.src || "";
+    return upsertActivityEmbedding({
+      activity_id: act.title,
+      textForEmbedding: `${act.title}. ${act.desc}`,
+      metadata: {
+        title: act.title,
+        desc: act.desc,
+        tags: act.tags,
+        time: act.time,
+        image: imageUrl,
+      },
+    });
+  });
+
+  const results = await Promise.allSettled(upsertPromises);
+
+  const successfulUpserts = results.filter((r) => r.status === "fulfilled").length;
+  results.forEach((result, index) => {
+    if (result.status === "rejected") {
+      console.error(`Failed to embed activity "${activities[index].title}":`, result.reason);
+    }
+  });
+
+  return NextResponse.json({
+    total: activities.length,
+    indexed: successfulUpserts,
+    failed: activities.length - successfulUpserts,
+  });
+}


### PR DESCRIPTION
- Replace simple string comparison with timingSafeEqual to prevent timing attacks
- Add proper error handling for missing REINDEX_SECRET
- Parallelize activity embedding operations using Promise.allSettled
- Provide more detailed response including failed operations count