### PR TITLE
fix(SmokeEffect): increase smoke animation duration for better visibility

### DIFF
--- a/src/styles/SmokeEffect.css
+++ b/src/styles/SmokeEffect.css
@@ -7,7 +7,7 @@
     opacity: 0;
     filter: blur(5px);
     transform: scale(1);
-    animation: smoke-animation 0.5s ease-out forwards;
+    animation: smoke-animation 1s ease-out forwards;
   }
   
   @keyframes smoke-animation {


### PR DESCRIPTION

The animation duration was too short, making the smoke effect barely noticeable. Increased from 0.5s to 1s to improve visibility while maintaining smooth transition.