### PR TITLE
feat(itinerary-generator): adjust model params and add peak hours context

### DIFF
--- a/src/app/api/gemini/itinerary-generator/agent/agent.ts
+++ b/src/app/api/gemini/itinerary-generator/agent/agent.ts
@@ -47,8 +47,8 @@ export async function proposeSubqueries(params: {
     const resp = await model.generateContent({
       contents: [{ role: "user", parts: [{ text: guidance + "\n\nUser prompt: " + userPrompt }] }],
       generationConfig: {
-        temperature: 0.7,
-        maxOutputTokens: 1024
+        temperature: 2,
+        maxOutputTokens: 8192
       }
     });
     const text = resp.response?.text() ?? "";

--- a/src/app/api/gemini/itinerary-generator/lib/responseHandler.ts
+++ b/src/app/api/gemini/itinerary-generator/lib/responseHandler.ts
@@ -41,8 +41,8 @@ export async function generateItinerary(detailedPrompt: string, prompt: string, 
     return result.response;
 }
 
-export async function handleItineraryProcessing(parsed: any, prompt: string, durationDays: number | null) {
-    let processed = await processItinerary(parsed, prompt, durationDays, geminiModel);
+export async function handleItineraryProcessing(parsed: any, prompt: string, durationDays: number | null, peakHoursContext: string) {
+    let processed = await processItinerary(parsed, prompt, durationDays, geminiModel, peakHoursContext);
 
     if (!processed || !processed.items || processed.items.length === 0) {
         const isReasonProvided = processed.subtitle && processed.subtitle.toLowerCase().includes("could not find");

--- a/src/app/api/gemini/itinerary-generator/route/route.ts
+++ b/src/app/api/gemini/itinerary-generator/route/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { geminiModel, responseCache, CACHE_DURATION, API_KEY } from "../lib/config";
+import { getPeakHoursContext } from "@/lib/peakHours";
 import { buildDetailedPrompt } from "../lib/contextBuilder";
 import { findAndScoreActivities } from "../lib/activitySearch";
 import { generateItinerary, handleItineraryProcessing, parseAndCleanJson } from "../lib/responseHandler";
@@ -82,8 +83,9 @@ export async function POST(req: NextRequest) {
             }
         }
 
+        const peakHoursContext = getPeakHoursContext();
         let parsed = parseAndCleanJson(finalText);
-        const finalItinerary = await handleItineraryProcessing(parsed, prompt, durationDays);
+        const finalItinerary = await handleItineraryProcessing(parsed, prompt, durationDays, peakHoursContext);
         const responseData = { text: JSON.stringify(finalItinerary) };
         responseCache.set(cacheKey, { response: responseData, timestamp: Date.now() });
         return NextResponse.json(responseData);

--- a/src/app/api/gemini/itinerary-generator/utils/itineraryUtils.ts
+++ b/src/app/api/gemini/itinerary-generator/utils/itineraryUtils.ts
@@ -42,7 +42,8 @@ export async function ensureFullItinerary(
   itinerary: any,
   userPrompt: string,
   durationDays: number,
-  model: ReturnType<GoogleGenerativeAI["getGenerativeModel"]>
+  model: ReturnType<GoogleGenerativeAI["getGenerativeModel"]>,
+  peakHoursContext: string
 ): Promise<any> {
   const dayActivities: { [key: string]: any[] } = {};
   for (const item of itinerary.items) {
@@ -95,6 +96,7 @@ export async function ensureFullItinerary(
       - Duration of the trip
       - Common travel wisdom (e.g., rest periods, meal times, travel time)
       - Activities already scheduled for that day
+      - Current traffic conditions: ${peakHoursContext}
 
       USER TRIP REQUEST: "${userPrompt}"
 
@@ -240,11 +242,11 @@ export function validateAndEnrichActivity(activity: any): any | null {
   };
 }
 
-export async function processItinerary(parsed: any, prompt: string, durationDays: number | null, model: any) {
+export async function processItinerary(parsed: any, prompt: string, durationDays: number | null, model: any, peakHoursContext: string) {
   let processed = removeDuplicateActivities(parsed);
   processed = organizeItineraryByDays(processed, durationDays);
   if (durationDays && model) {
-    processed = await ensureFullItinerary(processed, prompt, durationDays, model);
+    processed = await ensureFullItinerary(processed, prompt, durationDays, model, peakHoursContext);
   }
 
   // Final cleanup and validation pass.


### PR DESCRIPTION


- Increase temperature to 2 and max output tokens to 8192 for more creative responses
- Add peak hours context parameter to itinerary processing functions
- Include traffic conditions in itinerary generation prompt