### PR TITLE
feat(MapUI): add VERY_LOW traffic color to legend

### DIFF
--- a/src/app/dashboard/components/route/MapUI/TrafficLegend.tsx
+++ b/src/app/dashboard/components/route/MapUI/TrafficLegend.tsx
@@ -10,6 +10,7 @@ interface TrafficLegendProps {
 }
 
 const trafficColorMap = {
+  VERY_LOW: 'bg-emerald-400',
   LOW: 'bg-green-500',
   MODERATE: 'bg-yellow-500',
   HIGH: 'bg-orange-500',


### PR DESCRIPTION
Add new color mapping for VERY_LOW traffic level to match updated traffic data classifications