### PR TITLE
refactor(gemini): use configurable model id with fallback

### DIFF
--- a/src/app/api/gemini/itinerary-generator/lib/config.ts
+++ b/src/app/api/gemini/itinerary-generator/lib/config.ts
@@ -4,7 +4,16 @@ import type { WeatherCondition } from "../types/types";
 // Global initialization for Gemini model to avoid re-creating the client on every request.
 export const API_KEY = process.env.GOOGLE_GEMINI_API_KEY || "";
 export const genAI = API_KEY ? new GoogleGenerativeAI(API_KEY) : null;
-export const geminiModel = genAI ? genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" }) : null;
+
+const DEFAULT_MODEL_ID = "gemini-2.5-pro";
+const configuredModelId = process.env.GOOGLE_GEMINI_MODEL?.trim();
+const MODEL_ID = configuredModelId && configuredModelId.length > 0 ? configuredModelId : DEFAULT_MODEL_ID;
+
+if (!configuredModelId) {
+  console.warn(`[Gemini] GOOGLE_GEMINI_MODEL not set. Falling back to default model: ${DEFAULT_MODEL_ID}`);
+}
+
+export const geminiModel = genAI ? genAI.getGenerativeModel({ model: MODEL_ID }) : null;
 
 
 // Pre-computed weather context lookup for faster processing


### PR DESCRIPTION
Add support for configuring the Gemini model ID via environment variable while maintaining a default fallback. Warn when using the default model to make configuration issues more visible.